### PR TITLE
Update to latest VC Bitstring Status List context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @digitalbazaar/vc-bitstring-status-list-context ChangeLog
 
+## 1.1.0 - 2025-02-xx
+
+### Changed
+- Update to latest VC Bitstring Status List context.
+  - Align with VC Bitstring Status List spec.
+￼ - Move `statusMessage`, `statusReference`, and `statusSize` from
+￼    `BitstringStatusList` to `BitstringStatusListEntry`.
+  - Change `statusSize` data type from `xsd:positiveInteger` to `xsd:integer`.
+  - Add missing `id` and `type` terms.
+  - Add type for `statusReference` and `statusSize`.
+
 ## 1.0.0 - 2024-02-19
 
 - Initial version.

--- a/contexts/vc-bitstring-status-list-v1.jsonld
+++ b/contexts/vc-bitstring-status-list-v1.jsonld
@@ -1,6 +1,8 @@
 {
   "@context": {
     "@protected": true,
+    "id": "@id",
+    "type": "@type",
     "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
     "BitstringStatusList": {
       "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
@@ -8,24 +10,12 @@
         "@protected": true,
         "id": "@id",
         "type": "@type",
-        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
         "encodedList": {
           "@id": "https://www.w3.org/ns/credentials/status#encodedList",
           "@type": "https://w3id.org/security#multibase"
         },
-        "ttl": "https://www.w3.org/ns/credentials/status#ttl",
-        "statusReference": "https://www.w3.org/ns/credentials/status#statusReference",
-        "statusSize": "https://www.w3.org/ns/credentials/status#statusSize",
-        "statusMessage": {
-          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
-          "@context": {
-            "@protected": true,
-            "id": "@id",
-            "type": "@type",
-            "status": "https://www.w3.org/ns/credentials/status#status",
-            "message": "https://www.w3.org/ns/credentials/status#message"
-          }
-        }
+        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "ttl": "https://www.w3.org/ns/credentials/status#ttl"
       }
     },
     "BitstringStatusListEntry": {
@@ -34,11 +24,29 @@
         "@protected": true,
         "id": "@id",
         "type": "@type",
-        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
-        "statusListIndex": "https://www.w3.org/ns/credentials/status#statusListIndex",
         "statusListCredential": {
           "@id": "https://www.w3.org/ns/credentials/status#statusListCredential",
           "@type": "@id"
+        },
+        "statusListIndex": "https://www.w3.org/ns/credentials/status#statusListIndex",
+        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "statusMessage": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "message": "https://www.w3.org/ns/credentials/status#message",
+            "status": "https://www.w3.org/ns/credentials/status#status"
+          }
+        },
+        "statusReference": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusReference",
+          "@type": "@id"
+        },
+        "statusSize": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
+          "@type": "https://www.w3.org/2001/XMLSchema#integer"
         }
       }
     }

--- a/js/context.js
+++ b/js/context.js
@@ -11,6 +11,9 @@ export default
   "@context": {
     "@protected": true,
 
+    "id": "@id",
+    "type": "@type",
+
     "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
 
     "BitstringStatusList": {
@@ -21,29 +24,13 @@ export default
         "id": "@id",
         "type": "@type",
 
-        "statusPurpose":
-          "https://www.w3.org/ns/credentials/status#statusPurpose",
         "encodedList": {
           "@id": "https://www.w3.org/ns/credentials/status#encodedList",
           "@type": "https://w3id.org/security#multibase"
         },
-        "ttl": "https://www.w3.org/ns/credentials/status#ttl",
-        "statusReference":
-          "https://www.w3.org/ns/credentials/status#statusReference",
-        "statusSize":
-          "https://www.w3.org/ns/credentials/status#statusSize",
-        "statusMessage": {
-          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
-          "@context": {
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "status": "https://www.w3.org/ns/credentials/status#status",
-            "message": "https://www.w3.org/ns/credentials/status#message"
-          }
-        }
+        "statusPurpose":
+          "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "ttl": "https://www.w3.org/ns/credentials/status#ttl"
       }
     },
 
@@ -56,14 +43,34 @@ export default
         "id": "@id",
         "type": "@type",
 
-        "statusPurpose":
-          "https://www.w3.org/ns/credentials/status#statusPurpose",
-        "statusListIndex":
-          "https://www.w3.org/ns/credentials/status#statusListIndex",
         "statusListCredential": {
           "@id":
             "https://www.w3.org/ns/credentials/status#statusListCredential",
           "@type": "@id"
+        },
+        "statusListIndex":
+          "https://www.w3.org/ns/credentials/status#statusListIndex",
+        "statusPurpose":
+          "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "statusMessage": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "message": "https://www.w3.org/ns/credentials/status#message",
+            "status": "https://www.w3.org/ns/credentials/status#status"
+          }
+        },
+        "statusReference": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusReference",
+          "@type": "@id"
+        },
+        "statusSize": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
+          "@type": "https://www.w3.org/2001/XMLSchema#integer"
         }
       }
     }


### PR DESCRIPTION
- Align with VC Bitstring Status List spec.
- Move `statusMessage`, `statusReference`, and `statusSize` from `BitstringStatusList` to `BitstringStatusListEntry`.
- Change `statusSize` data type from `xsd:positiveInteger` to `xsd:integer`.
- Add missing `id` and `type` terms.
- Add type for `statusReference` and `statusSize`.